### PR TITLE
Fix for builds failing when Target is not Editor

### DIFF
--- a/RakNet/Source/RakNet/Public/RakNetTestTool.cpp
+++ b/RakNet/Source/RakNet/Public/RakNetTestTool.cpp
@@ -1,6 +1,7 @@
 ﻿// Copyright 1998-2015 Epic Games, Inc. All Rights Reserved.
 
 
+#if UE_EDITOR
 #include "RakNetPrivatePCH.h"
 #include "RakNetTestTool.h"
 #include "LevelEditor.h"
@@ -229,3 +230,5 @@ void FRakNetTestTool::OnRakNetPingClient()
 
 
 #undef LOCTEXT_NAMESPACE
+
+#endif // UE_EDITOR

--- a/RakNet/Source/RakNet/Public/RakNetTestTool.h
+++ b/RakNet/Source/RakNet/Public/RakNetTestTool.h
@@ -8,6 +8,10 @@
 #include "IPluginManager.h"
 #include "ModuleManager.h"
 
+namespace RakNet {
+	class RakPeerInterface;
+}
+
 
 DECLARE_LOG_CATEGORY_EXTERN(LogRakNetTestTool, Log, All);
 

--- a/RakNet/Source/RakNet/RakNet.Build.cs
+++ b/RakNet/Source/RakNet/RakNet.Build.cs
@@ -36,12 +36,8 @@ namespace UnrealBuildTool.Rules
 				new string[]
 				{
                     "Core",
-                    "Engine",
-                    "UnrealEd",
-                    "LevelEditor",
-                    "Slate",
+                    "Engine"
 					// ... add private dependencies that you statically link with here ...
-                    //"RakNet",
                 }
 				);
 
@@ -51,6 +47,17 @@ namespace UnrealBuildTool.Rules
 					// ... add any modules that your module loads dynamically here ...
 				}
 				);
+
+            if(Target.Type == TargetRules.TargetType.Editor)
+            {
+                // These modules are only needed for RakNetTestTool
+                PrivateDependencyModuleNames.AddRange(new string[] {
+                    "LevelEditor",
+                    "UnrealEd",
+                    "Slate"
+                });
+
+            }
 		}
 	}
 }


### PR DESCRIPTION
When building for UE 4.12, this plugin worked fine for all development in-editor. Upon deciding to test a packaged build, I found hundreds of strange compile errors scattered all around the engine. I tracked the errors back to this plugin through process of elimination, and found that removing these editor-only dependencies when not building toward the editor fixed all issues. They appear to only be required for the RakNetTestTool code, and can be safely omitted for non-editor builds. 
